### PR TITLE
Move props.block and props.elem to props.bem namespace

### DIFF
--- a/src/packages/bem/README.md
+++ b/src/packages/bem/README.md
@@ -96,10 +96,10 @@ import classnamesMap from './Button.scss';
 
 const ButtonStateless = (props) => {
     return (
-      {/*  1. Add { ...props.block() } construction to declare node as a block */}
-      <button { ...props.block() }>
-        {/*  2. Add { ...props.elem('label') } construction to declare node as a label element */}
-        <span { ...props.elem('label') }>
+      {/*  1. Add { ...props.bem.block() } construction to declare node as a block */}
+      <button { ...props.bem.block() }>
+        {/*  2. Add { ...props.bem.elem('label') } construction to declare node as a label element */}
+        <span { ...props.bem.elem('label') }>
             {props.children}
         </span>
       </button>

--- a/src/packages/bem/__tests__/dummy-components/ButtonStateless.jsx
+++ b/src/packages/bem/__tests__/dummy-components/ButtonStateless.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const ButtonStateless = (props) => (
-    <button { ...props.block() } type="button">
-        <span { ...props.elem('icon') } />
-        <span { ...props.elem('label') }>
+    <button { ...props.bem.block() } type="button">
+        <span { ...props.bem.elem('icon') } />
+        <span { ...props.bem.elem('label') }>
             {props.children}
         </span>
     </button>

--- a/src/packages/bem/bem.js
+++ b/src/packages/bem/bem.js
@@ -77,22 +77,24 @@ function bemStateless(classnamesMap) {
         return props => {
             const propsWithBEMTaste = {
                 ...props,
-                block: () =>
-                    buildBemProps({
-                        block: blockName,
-                        elem: null,
-                        props,
-                        propsToMods,
-                        classnamesMap
-                    }),
-                elem: elemName =>
-                    buildBemProps({
-                        block: blockName,
-                        elem: elemName,
-                        props,
-                        propsToMods,
-                        classnamesMap
-                    })
+                bem: {
+                    block: () =>
+                        buildBemProps({
+                            block: blockName,
+                            elem: null,
+                            props,
+                            propsToMods,
+                            classnamesMap,
+                        }),
+                    elem: elemName =>
+                        buildBemProps({
+                            block: blockName,
+                            elem: elemName,
+                            props,
+                            propsToMods,
+                            classnamesMap,
+                        })
+                }
             };
 
             return <StatelessBEMComponent {...propsWithBEMTaste} />;


### PR DESCRIPTION
* Since now for stateless components you need to call props.bem.block() props.bem.elem('elemName')